### PR TITLE
Handle LIMA connection test after GUI init

### DIFF
--- a/main.py
+++ b/main.py
@@ -80,9 +80,10 @@ class ProduktManagerApp(ctk.CTk):
         
         # Daten laden
         self._load_initial_data()
-        
+
         # Verbindungen testen
-        self._test_connections()
+        # Verzögerung einbauen, damit die GUI zuerst erscheint
+        self.after(100, self._test_connections)
         
         self.logger.info("THT-Produktmanager erfolgreich gestartet")
     


### PR DESCRIPTION
## Summary
- delay LIMA connection test so GUI loads before network check

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689afc100480833182c6bd621ae3d5aa