### PR TITLE
Log incoming messages in listener

### DIFF
--- a/communication_manager.py
+++ b/communication_manager.py
@@ -366,13 +366,15 @@ class ListenerMode:
         try:
             sender_ip = address[0]
             self.logger.info(f"Client verbunden: {sender_ip}")
-            
+            self._log_event("CLIENT_CONNECTED", f"Verbunden mit {sender_ip}", sender_ip)
+
             # Nachricht empfangen - HIER WAR DER FEHLER: .strip() statt .strip
             data = client_socket.recv(4096).decode("utf-8").strip()
-            
+            self._log_event("MESSAGE_RECEIVED", data, sender_ip)
+
             if data and self.message_handler:
                 self.message_handler(data, sender_ip)
-                
+
                 # Bestätigung senden
                 response = "MESSAGE_RECEIVED"
                 client_socket.send(response.encode("utf-8"))
@@ -395,9 +397,8 @@ class ListenerMode:
                 
                 # Ausgehende Nachricht loggen
                 self._log_event("MESSAGE_SENT", message, self.send_ip)
-                
+
                 sock.send(message.encode("utf-8"))
-                self._log_event("MESSAGE_SENT", message, self.send_ip)
 
                 # Bestätigung empfangen
                 response = sock.recv(1024).decode("utf-8").strip()


### PR DESCRIPTION
## Summary
- Log CLIENT_CONNECTED and MESSAGE_RECEIVED events in listener for incoming sockets
- Remove duplicate MESSAGE_SENT log in send_message to avoid redundant entries

## Testing
- `python -m py_compile communication_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad6ff01ee48331a607d9ccf31b898c