### PR TITLE
Add camera TCP client to ListenerMode

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,9 +44,21 @@ def _start_listener_mode(self):
         listen_port = int(self.listener_port_entry.get())
         send_ip = self.send_ip_entry.get()
         send_port = int(self.send_port_entry.get())
-        
+
+        camera_ip = (
+            self.ip_entry.get()
+            if hasattr(self, "ip_entry")
+            else self.lima_config.get("ip", Config.DEFAULT_LIMA_CONFIG["ip"])
+        )
+
         # Listener-Modus starten
-        self.listener_mode = ListenerMode(listen_port, send_ip, send_port)
+        self.listener_mode = ListenerMode(
+            listen_port,
+            send_ip,
+            send_port,
+            camera_ip=camera_ip,
+            camera_port=34000,
+        )
         success = self.listener_mode.start(
             self._handle_listener_message,
             self._on_listener_log_event  # Neuer Log-Callback


### PR DESCRIPTION
## Summary
- extend ListenerMode to also act as TCP client for camera trigger messages
- allow passing camera IP from GUI and start camera client alongside server
- fix duplicate MESSAGE_SENT logging

## Testing
- `python -m py_compile communication_manager.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad7e03d64483319dde909cb0d16697