### PR TITLE
Display sent messages in listener log

### DIFF
--- a/main.py
+++ b/main.py
@@ -1058,6 +1058,7 @@ class ProduktManagerApp(ctk.CTk):
                     self.listener_mode.send_ip,
                     self.listener_mode.send_port,
                     self.logger,
+                    self.listener_mode._log_event,
                 )
 
             # Zusätzliche Befehle verarbeiten


### PR DESCRIPTION
## Summary
- Log outbound listener messages using a callback so they appear in the listener window
- Forward ListenerMode's log_event into listener payload processing for consistent tracking

## Testing
- `python -m py_compile listener_processor.py main.py`


