### PR TITLE
Handle LIMA XML parsing errors with ET.ParseError

### DIFF
--- a/communication_manager.py
+++ b/communication_manager.py
@@ -75,8 +75,9 @@ class LimaClient:
             
             return attributes
         
-        except ET.XMLSyntaxError as e:
-            self.logger.error(f"XML-Parse-Fehler: {e}")
+        except ET.ParseError as e:
+            # Logge die komplette fehlerhafte XML-Antwort zur Analyse
+            self.logger.error(f"XML-Parse-Fehler: {e} - Antwort: {response}")
             return {}
         except Exception as e:
             self.logger.error(f"Fehler beim Parsen der LIMA-Response: {e}")


### PR DESCRIPTION
## Summary
- Replace deprecated `ET.XMLSyntaxError` with `ET.ParseError` in LIMA response parser
- Log malformed XML responses to aid debugging

## Testing
- `pytest -q`

