### PR TITLE
Use bcrypt-hashed admin password from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,26 @@ Die Anwendung ist ein THT‑Produktmanager mit einer grafischen Oberfläche (GUI
 
         UI‑Updates und Programmende (Cleanup).
 
+## Admin-Passwort konfigurieren
 
-Eine Software Anleitung für den Endutzer befindet sich in Arbeit. 
+Der Admin-Zugang verwendet einen bcrypt-Hash, der über die Umgebungsvariable
+`ADMIN_PASSWORD_HASH` bereitgestellt wird. Zum Setzen des Passworts:
+
+1. Hash erzeugen:
+   ```bash
+   python -c "import bcrypt, getpass; print(bcrypt.hashpw(getpass.getpass().encode(), bcrypt.gensalt()).decode())"
+   ```
+   Das Kommando fragt nach dem neuen Passwort und gibt den Hash aus.
+2. Hash als Umgebungsvariable setzen (Beispiel Linux/macOS):
+   ```bash
+   export ADMIN_PASSWORD_HASH='hier-den-ausgegebenen-hash-einfügen'
+   ```
+   Unter Windows kann die Variable über `set` oder die Systemsteuerung gesetzt werden.
+
+Beim Programmstart wird der Hash aus der Umgebung gelesen und eingegebene
+Passwörter werden dagegen geprüft.
+
+Eine Software Anleitung für den Endutzer befindet sich in Arbeit.
 
 
 🦾 RTDE-Integration (UR Cobot)

--- a/config.py
+++ b/config.py
@@ -7,9 +7,11 @@ import os
 class Config:
     # Datenbankeinstellungen
     DB_FILE = "produktkatalog.db"
-    
-    # Admin-Einstellungen
-    ADMIN_PASSWORD = "admin123"
+
+    @staticmethod
+    def get_admin_password_hash() -> str:
+        """Liest den Hash des Admin-Passworts aus der Umgebungsvariable."""
+        return os.environ.get("ADMIN_PASSWORD_HASH", "")
     
     # Dateipfade
     LIMA_CONFIG_FILE = "lima_config.json"

--- a/main.py
+++ b/main.py
@@ -389,8 +389,9 @@ class ProduktManagerApp(ctk.CTk):
             
             if not password:
                 return
-            
-            if not Validator.validate_password(password, Config.ADMIN_PASSWORD):
+
+            password_hash = Config.get_admin_password_hash()
+            if not password_hash or not Validator.validate_password(password, password_hash):
                 raise AuthenticationError("Falsches Passwort")
             
             self.admin_mode = True

--- a/validation.py
+++ b/validation.py
@@ -5,6 +5,8 @@ import socket
 import re
 from typing import Any, Optional
 
+import bcrypt
+
 from exceptions import ValidationError
 from config import Config
 
@@ -65,9 +67,14 @@ class Validator:
         return isinstance(field, str) and field in Config.AF_FIELDS
     
     @staticmethod
-    def validate_password(password: str, expected: str) -> bool:
-        """Validiert Passwort"""
-        return password == expected
+    def validate_password(password: str, password_hash: str) -> bool:
+        """Prüft ein Passwort gegen einen bcrypt-Hash."""
+        if not password_hash:
+            return False
+        try:
+            return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
+        except ValueError:
+            return False
     
     @staticmethod
     def sanitize_string(value: str) -> str:


### PR DESCRIPTION
## Summary
- Load admin password hash from `ADMIN_PASSWORD_HASH` environment variable.
- Validate admin password using bcrypt hash instead of plain comparison.
- Document setup of the admin password hash in the README.

## Testing
- `python -m py_compile config.py main.py validation.py`
- `pytest -q`
- ⚠️ `pip install bcrypt` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b51bb599048331b8bf2e8fea24aef0