### PR TITLE
Vereinfache LimaClient und entferne Chunk-Test

### DIFF
--- a/communication_manager.py
+++ b/communication_manager.py
@@ -42,50 +42,31 @@ class LimaClient:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                 sock.settimeout(self.timeout)
                 sock.connect((self.host, self.port))
-                
+
                 # LIMA-Kommando mit Newline senden
                 full_command = command + "\n"
-                sock.send(full_command.encode('utf-8'))
-                
-                # Antwort zeilenweise lesen
-                try:
-                    with sock.makefile("r", encoding="utf-8", newline="\n") as stream:
-                        response_parts = []
-                        while True:
-                            line = stream.readline()
-                            if line == "":
-                                raise CommunicationError(
-                                    f"Verbindung beendet während Kommando: {command}"
-                                )
-                            response_parts.append(line)
-                            if line.endswith("\n"):
-                                break
-                    response = "".join(response_parts).strip()
-                except socket.timeout as exc:
-                    raise CommunicationError(
-                        f"Timeout beim Lesen der Antwort: {command}"
-                    ) from exc
+                sock.send(full_command.encode("utf-8"))
 
+                # Antwort empfangen (bis zu 4KB)
+                response = sock.recv(4096).decode("utf-8").strip()
                 self.logger.debug(
                     "LIMA Kommando: %s -> Antwort: %s", command, response
                 )
 
                 return response
 
-        except socket.timeout as exc:
+        except socket.timeout:
             raise CommunicationError(
                 f"Timeout beim Senden des Kommandos: {command}"
-            ) from exc
-        except (socket.error, OSError) as e:
+            )
+        except socket.error as e:
             raise CommunicationError(
                 f"Socket-Fehler bei Kommando {command}: {e}"
-            ) from e
-        except CommunicationError:
-            raise
+            )
         except Exception as e:
             raise CommunicationError(
                 f"Unerwarteter Fehler bei Kommando {command}: {e}"
-            ) from e
+            )
     
     def parse_lima_response(self, response: str) -> Dict[str, str]:
         """Parst LIMA XML-Response"""

--- a/tests/test_lima_client.py
+++ b/tests/test_lima_client.py
@@ -10,7 +10,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from communication_manager import LimaClient
 
 
-def _start_chunked_server(response_chunks):
+def _start_server(response: str):
     port_holder = []
 
     def server():
@@ -20,11 +20,8 @@ def _start_chunked_server(response_chunks):
             port_holder.append(s.getsockname()[1])
             conn, _ = s.accept()
             with conn:
-                conn.recv(1024)  # receive command
-                for chunk in response_chunks:
-                    conn.sendall(chunk.encode("utf-8"))
-                    time.sleep(0.05)
-                conn.sendall(b"\n")
+                conn.recv(1024)
+                conn.sendall(response.encode("utf-8"))
 
     thread = threading.Thread(target=server, daemon=True)
     thread.start()
@@ -34,8 +31,8 @@ def _start_chunked_server(response_chunks):
     return port_holder[0], thread
 
 
-def test_send_command_reads_chunked_response():
-    port, thread = _start_chunked_server(["<TO", "k/>"])
+def test_send_command_receives_response():
+    port, thread = _start_server("<TOk/>\n")
     client = LimaClient("127.0.0.1", port, timeout=1.0)
 
     result = client.send_command("<T/>")


### PR DESCRIPTION
## Zusammenfassung
- Verwende wieder einfaches `recv` in `LimaClient.send_command` und logge Antwort.
- Entferne zeilenweises Lesen und handle Standard-Socket-Fehler.
- Passe Unit-Test an, um vollständige Antwort ohne Chunking zu prüfen.

## Testdurchführung
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12f05a64883318c7ad36d1c95afcc