### PR TITLE
Format listener output as key-value pairs

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ Zentralisierte Konfiguration für den THT-Produktmanager
 """
 from typing import Dict, Any
 import os
+import re
 
 class Config:
     # Datenbankeinstellungen
@@ -52,13 +53,49 @@ class Config:
     POSITION_FIELDS = [
         "PosPCB_0", "PosPCB_1", "PosPCB_2", "PosPCB_3", "PosPCB_4"
     ]
+
+    # Kurzbezeichnungen für Felder (für Cobot-Kommunikation)
+    FIELD_CODES: Dict[str, str] = {
+        "Laufende Nummer": "LNR",
+        "Produktnummer": "PNR",
+        "Kunde": "KND",
+        "Notizen": "NOT",
+        "Frame Width (mm)": "FW",
+        "Frame Height (mm)": "FH",
+        "PCB_0 Top": "PCB0T",
+        "PCB_1 Back": "PCB1B",
+        "PCB_2 Right": "PCB2R",
+        "PCB_3 Front": "PCB3F",
+        "PCB_4 Left": "PCB4L",
+        "AF Breite": "AFB",
+        "AF Höhe": "AFH",
+        "AF Tiefe": "AFT",
+        "AI angelegt": "AIAN",
+        "AI Zeitstempel": "AITS",
+        "Cobot angelegt": "COAN",
+        "Cobot Zeitstempel": "COTS",
+        "PosPCB_0": "POS0",
+        "PosPCB_1": "POS1",
+        "PosPCB_2": "POS2",
+        "PosPCB_3": "POS3",
+        "PosPCB_4": "POS4",
+    }
     
     @classmethod
     def get_all_fields(cls) -> list:
         """Gibt alle Felder in der korrekten Reihenfolge zurück"""
-        return (cls.BASIC_FIELDS + cls.DIMENSION_FIELDS + 
-                cls.PCB_FIELDS + cls.AF_FIELDS + cls.EXTRA_FIELDS + 
+        return (cls.BASIC_FIELDS + cls.DIMENSION_FIELDS +
+                cls.PCB_FIELDS + cls.AF_FIELDS + cls.EXTRA_FIELDS +
                 cls.POSITION_FIELDS)
+
+    @classmethod
+    def get_field_code(cls, field: str) -> str:
+        """Liefert die Kurzbezeichnung eines Felds.
+
+        Falls keine explizite Abkürzung vorhanden ist, wird eine generische
+        Variante (Großbuchstaben ohne Sonderzeichen) zurückgegeben.
+        """
+        return cls.FIELD_CODES.get(field, re.sub(r"\W+", "", field).upper())
     
     # LIMA-Kommandos
     LIMA_COMMANDS = {

--- a/listener_processor.py
+++ b/listener_processor.py
@@ -21,12 +21,17 @@ def _get_product_row_by_wu(db: DatabaseManager, wu: str) -> Optional[dict]:
 
 
 def _format_row_as_underscore_string(row: dict, fields: List[str] | None = None) -> str:
-    """Formatiert eine Datenbankzeile als Unterstrich-getrennten String."""
+    """Formatiert eine Datenbankzeile als "KEY:WERT"-Paare."""
     if not row:
         return ""
+
     field_order = fields if fields is not None else Config.get_all_fields()
-    vals = [str(row.get(k, "")) for k in field_order]
-    return "_".join(vals)
+    parts: List[str] = []
+    for field in field_order:
+        code = Config.get_field_code(field)
+        val = str(row.get(field, ""))
+        parts.append(f"{code}:{val}")
+    return "_".join(parts)
 
 
 def _send_to_cobot(ip: str, port: int, message: str, read_ok: bool = True, timeout: float = 5.0) -> bool:

--- a/tests/test_listener_processor.py
+++ b/tests/test_listener_processor.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from listener_processor import _format_row_as_underscore_string
+
+
+def test_format_row_with_codes():
+    row = {
+        "Laufende Nummer": 1,
+        "Produktnummer": "WU123",
+        "Kunde": "ACME",
+    }
+    fields = ["Laufende Nummer", "Produktnummer", "Kunde"]
+    result = _format_row_as_underscore_string(row, fields)
+    assert result == "LNR:1_PNR:WU123_KND:ACME"
+
+
+def test_format_row_none():
+    assert _format_row_as_underscore_string(None) == ""


### PR DESCRIPTION
## Summary
- senden aller Datenbankfelder als KEY:VALUE-Paare mit Unterstrichtrennung
- Mapping von Feldnamen zu Kurzbezeichnungen in die Konfiguration integriert
- Unit-Test für Listener-Formatierung ergänzt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c13303b4548331baa39461be52f7af