### PR TITLE
Handle additional WU/WUBRE formats

### DIFF
--- a/listener_processor.py
+++ b/listener_processor.py
@@ -77,6 +77,7 @@ def handle_listener_payload(payload: str, db: DatabaseManager, send_ip: str, sen
         if row
         else "NichtVorhanden"
     )
+    message += "END"
 
     # Gesendete Nachricht im Listener-Fenster anzeigen
     if log_event:

--- a/listener_processor.py
+++ b/listener_processor.py
@@ -6,8 +6,10 @@ from typing import Optional, List, Callable
 from database_manager import DatabaseManager
 from config import Config
 
-# Unterstützt Produktnummern im Format "WU123" oder "WUBRE123".
-PRODUCT_RE = re.compile(r"\b(?:WU|WUBRE)\d+\b")
+# Unterstützt Produktnummern im Format "WU123", "WUBRE123" sowie
+# Varianten mit optionalem Bindestrich, Kleinschreibung und optionalen
+# Buchstaben am Ende (z.B. "wu-123cu").
+PRODUCT_RE = re.compile(r"\b(?:WU|WUBRE)-?\d+[A-Z]*\b", re.IGNORECASE)
 # Rückwärtskompatibler Alias
 WU_RE = PRODUCT_RE
 

--- a/tests/test_listener_processor.py
+++ b/tests/test_listener_processor.py
@@ -1,8 +1,10 @@
 import sys
 from pathlib import Path
+import logging
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import listener_processor
 from listener_processor import _format_row_as_underscore_string
 
 
@@ -43,3 +45,31 @@ def test_extract_wu_with_trailing_letters():
     from listener_processor import _extract_wu
 
     assert _extract_wu(payload) == "WU0000003CU"
+
+
+def test_handle_listener_payload_appends_end(monkeypatch):
+    class DummyDB:
+        def get_by_wu(self, wu):
+            return {"Laufende Nummer": 1, "Produktnummer": wu, "Kunde": "ACME"}
+
+    sent: dict = {}
+
+    def fake_send(ip: str, port: int, message: str, read_ok: bool = True, timeout: float = 5.0) -> bool:
+        sent["msg"] = message
+        return True
+
+    monkeypatch.setattr(listener_processor, "_send_to_cobot", fake_send)
+
+    log_messages: list = []
+
+    def log_event(event: str, message: str, ip: str) -> None:
+        log_messages.append(message)
+
+    logger = logging.getLogger("test")
+
+    listener_processor.handle_listener_payload(
+        "WU123", DummyDB(), "127.0.0.1", 1234, logger, log_event
+    )
+
+    assert sent["msg"].endswith("END")
+    assert log_messages[0].endswith("END")

--- a/tests/test_listener_processor.py
+++ b/tests/test_listener_processor.py
@@ -26,3 +26,20 @@ def test_extract_wubre_number():
     from listener_processor import _extract_wu
 
     assert _extract_wu(payload) == "WUBRE1234"
+
+
+def test_extract_wu_lowercase_with_dash():
+    payload = "foo wubre-1234 bar"
+    from listener_processor import _extract_wu
+
+    assert _extract_wu(payload) == "wubre-1234"
+
+
+def test_extract_wu_with_trailing_letters():
+    payload = (
+        "13:47:07.405 \u2b07\ufe0f [MESSAGE_RECEIVED] 10.3.218.3: "
+        "C:0F:6P:WU0000003CU:KundeBN:Arbeitsplatz 3"
+    )
+    from listener_processor import _extract_wu
+
+    assert _extract_wu(payload) == "WU0000003CU"


### PR DESCRIPTION
## Summary
- broaden WU/WUBRE pattern to accept lowercase, dashes and trailing letters
- add tests covering lowercase, dashed and suffixed variants

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c16732bfec83318fd66b691e6f21fd